### PR TITLE
Maintain scope even for ordinary dictionaries when unarchiving

### DIFF
--- a/HRCoder/HRCoder.m
+++ b/HRCoder/HRCoder.m
@@ -517,6 +517,7 @@
     {
         //ordinary dictionary
         NSMutableDictionary *result = [NSMutableDictionary dictionary];
+		[coder.stack addObject:self];
         for (NSString *key in self)
         {
             id object = [coder decodeObjectForKey:key];
@@ -527,7 +528,7 @@
 #if !__has_feature(objc_arc)
         [result autorelease];
 #endif
-        
+		[coder.stack removeLastObject];
         return result;
     }
 }


### PR DESCRIPTION
Nested dictionaries in a plist which had the same property names as a containing encoded object causes issues as scope was lost. The properties were mangled on the wrong object. This fix ensures that even ordinary dictionaries are pushed onto the stack when parsing to avoid this sort of thing happening. Possibly an argument for better structure in the plist but this was forced on us!

Hope this helps, and avoids hours of debugging for others who may use the library. Any issues with the fix please do get in touch.
